### PR TITLE
session-mongoose's package.json installs connect 2.0, with which it appears to be incompatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= v0.4.0"
   },
   "dependencies": {
-    "connect": ">= 1.0.0",
+    "connect": ">= 1.0.0 < 2",
     "mongeese": ">= 0.0.1"
   },
   "devDependencies": {}


### PR DESCRIPTION
I get this bug in my application when installing everything from npm fresh. It seems that session-mongoose is grabbing the latest version of connect which is not backwards compatible with it. I'm not entirely sure what's going on here, but other libraries are facing similar difficulties (related issue from connect-mongo - https://github.com/kcbanner/connect-mongo/issues/29)

```
DEBUG: 
node.js:201

DEBUG:         throw e; // process.nextTick error, or 'error' event on first tick
              ^

DEBUG: TypeError: Not a string or buffer
    at Object.createHmac (crypto.js:129:21)
    at Object.sign (/Users/cburt/Working/SeaSketch/node_modules/session-mongoose/node_modules/connect/lib/utils.js:135:6)
    at Object.serialize (/Users/cburt/Working/SeaSketch/node_modules/session-mongoose/node_modules/connect/lib/middleware/session/cookie.js:115:17)
    at ServerResponse.writeHead (/Users/cburt/Working/SeaSketch/node_modules/express/node_modules/connect/lib/middleware/session.js:265:46)
    at ServerResponse._implicitHeader (http.js:808:8)
    at ServerResponse.end (http.js:645:10)
    at ServerResponse.<anonymous> (/Users/cburt/Working/SeaSketch/node_modules/express/node_modules/connect/lib/middleware/logger.js:147:13)
    at IncomingMessage.next (/Users/cburt/Working/SeaSketch/node_modules/express/node_modules/connect/lib/http.js:167:13)
    at ServerResponse.render (/Users/cburt/Working/SeaSketch/node_modules/express/lib/view.js:328:16)
    at Promise.<anonymous> (/Users/cburt/Working/SeaSketch/app.coffee:124:22)

DEBUG: Program app.coffee exited with code 1

```
