### PR TITLE
Fixing typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configure Express
     app.use(express.session({
         store: store,
         cookie: { maxAge: 900000 } // expire session in 15 min or 900 seconds
-    });
+    }));
     ...
 
 Using custom connection


### PR DESCRIPTION
Fixes missing parens in the examples.

Pretty minor... 
